### PR TITLE
Make empty and expressions false

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,4 @@
 /target
+
+.*.sw*
+*.vim

--- a/lib/bootstrap/bootstrap.lisp
+++ b/lib/bootstrap/bootstrap.lisp
@@ -114,7 +114,7 @@
             (cons 'cond (cdr clauses)))))
 
 (defmacro and (&rest exprs)
-  (cond ((nil? exprs) true)
+  (cond ((nil? exprs) false)
         ((nil? (cdr exprs)) (car exprs))
         (true (list 'if (car exprs)
                  (cons 'and (cdr exprs))

--- a/tests/lisp/and.lisp
+++ b/tests/lisp/and.lisp
@@ -1,3 +1,4 @@
 (assert (and true true))
 (assert (and true))
 (assert (and (= 1 1) (= 'a 'a)))
+(assert (= (and) false))

--- a/tests/lisp/or.lisp
+++ b/tests/lisp/or.lisp
@@ -2,3 +2,4 @@
 (assert (= (or true true) true))
 (assert (= (or false true) true))
 (assert (= (or false false) false))
+(assert (= (or) false))


### PR DESCRIPTION
This way the following program:

    (if (and)
      (print "braindead")
      (print "less insane"))

    (if (or)
      (print "braindead")
      (print "less insane"))

will output:

    "less insane"
    "less insane"

instead of:

    "braindead"
    "less insane"